### PR TITLE
Fixup build failure with clang-11.0.0

### DIFF
--- a/machine/diagnostics/timing.hpp
+++ b/machine/diagnostics/timing.hpp
@@ -113,7 +113,7 @@ namespace timer {
     ~Running() {
       uint64_t now = get_current_time();
       uint64_t run = (now - start_) / ((uint64_t)factor);
-      if(last_) last_ = run;
+      if(last_) *last_ = run;
 
       result_ += run;
     }


### PR DESCRIPTION
```
/tmp/ruby-build.20201111212834.9644.4pUxsX/rubinius-5.0/machine/diagnostics/timing.hpp:116:25: error: incompatible integer to pointer conversion assigning to 'std::atomic<uint64_t> *' (aka 'atomic<unsigned long> *') from 'uint64_t' (aka 'unsigned long')
      if(last_) last_ = run;
                        ^~~
```

Thank you for taking the time to submit a pull-request to Rubinius. We appreciate your contribution.

Please respond to the following questions to help us merge your pull-request. Please leave the form contents in place. If a question isn't relevant, please respond with N/A.

1. Is this pull-request complete?

  - [ ] Yes, this pull-request is ready to be reviewed and merged.
  - [ ] No, this pull-request is a work-in-progress.

2. Does this pull request fix an issue with an existing feature or introduce a new feature?

  - [ ] It fixes an issue with an existing features.
  - [ ] It introduces a new feature.

3. Does this pull-request include tests?

  - [ ] Yes, it includes tests.
  - [ ] No, it does not include tests because the tests already exist.
  - [ ] No, it does not include tests because tests are too difficult to write.
  - [ ] No, it does not include tests because ...
