### PR TITLE
timing.hpp: Casting to atomic uint64_t before Running/last_ assignment

### DIFF
--- a/machine/diagnostics/timing.hpp
+++ b/machine/diagnostics/timing.hpp
@@ -112,8 +112,8 @@ namespace timer {
 
     ~Running() {
       uint64_t now = get_current_time();
-      uint64_t run = (now - start_) / ((uint64_t)factor);
-      if(last_) last_ = run;
+      uint64_t run = (now - start_) / factor;
+      if(last_) last_ = (std::atomic<uint64_t>*) run;
 
       result_ += run;
     }


### PR DESCRIPTION
This patch adds a cast for an assignment to an atomic integer value in timing.hpp

Previous to the patch, compiling Rubinius v5.0 with clang 11 on FreeBSD 11.1:

~~~~
4: CXX machine/accessor_primitives.cpp
In file included from machine/accessor_primitives.cpp:9: In file included from /usr/home/u1000/wk/dist_wk/ports_devo/lang/rubinius/work/rubinius-5.0/machine/includes.hpp:15: In file included from ./machine/class/block_environment.hpp:12: In file included from /usr/home/u1000/wk/dist_wk/ports_devo/lang/rubinius/work/rubinius-5.0/machine/class/variable_scope.hpp:9: In file included from /usr/home/u1000/wk/dist_wk/ports_devo/lang/rubinius/work/rubinius-5.0/machine/class/fiber.hpp:13:
/usr/home/u1000/wk/dist_wk/ports_devo/lang/rubinius/work/rubinius-5.0/machine/diagnostics/timing.hpp:116:25: error: incompatible integer to pointer conversion assigning to 'std::atomic<uint>
      if(last_) last_ = run;
                        ^~~
In file included from machine/bytecode_verifier.cpp:17:
/usr/home/u1000/wk/dist_wk/ports_devo/lang/rubinius/work/rubinius-5.0/machine/diagnostics/timing.hpp:116:25: error: incompatible integer to pointer conversion assigning to 'std::atomic<uint>
      if(last_) last_ = run;
                        ^~~
~~~~

Thank you for taking the time to submit a pull-request to Rubinius. We appreciate your contribution.

Please respond to the following questions to help us merge your pull-request. Please leave the form contents in place. If a question isn't relevant, please respond with N/A.

1. Is this pull-request complete?

  - [ ] Yes, this pull-request is ready to be reviewed and merged.
  - [ ] No, this pull-request is a work-in-progress.

2. Does this pull request fix an issue with an existing feature or introduce a new feature?

  - [ ] It fixes an issue with an existing features.
  - [ ] It introduces a new feature.

3. Does this pull-request include tests?

  - [ ] Yes, it includes tests.
  - [ ] No, it does not include tests because the tests already exist.
  - [ ] No, it does not include tests because tests are too difficult to write.
  - [ ] No, it does not include tests because ...
