### PR TITLE
rakelib install_file: pass options as **options

### DIFF
--- a/rakelib/install.rake
+++ b/rakelib/install.rake
@@ -43,7 +43,7 @@ def install_file(source, prefix, dest, name=nil, options={})
   options[:mode] ||= 0644
   options[:verbose] ||= $verbose
 
-  install source, dest_name, options
+  install source, dest_name, **options
 end
 
 def install_bin(source, target)


### PR DESCRIPTION
This patch ensures that any `options` hash provided to install_file be passed as **options to rake install

Thank you for taking the time to submit a pull-request to Rubinius. We appreciate your contribution.

Please respond to the following questions to help us merge your pull-request. Please leave the form contents in place. If a question isn't relevant, please respond with N/A.

1. Is this pull-request complete?

  - [ ] Yes, this pull-request is ready to be reviewed and merged.
  - [ ] No, this pull-request is a work-in-progress.

2. Does this pull request fix an issue with an existing feature or introduce a new feature?

  - [ ] It fixes an issue with an existing features.
  - [ ] It introduces a new feature.

3. Does this pull-request include tests?

  - [ ] Yes, it includes tests.
  - [ ] No, it does not include tests because the tests already exist.
  - [ ] No, it does not include tests because tests are too difficult to write.
  - [ ] No, it does not include tests because ...
